### PR TITLE
エラーメッセージ,修正

### DIFF
--- a/app/assets/stylesheets/purchases/_purchases.scss
+++ b/app/assets/stylesheets/purchases/_purchases.scss
@@ -210,7 +210,7 @@ body{
             .purchases-buy-item{
               width: 343px;
               height: 50px;
-              padding-top: 32px;      
+              padding-top: 28px;      
               border-top: 1px solid #f5f5f5;
               text-align: center;
               .alert {
@@ -259,5 +259,8 @@ body{
       display: block;
       margin: auto;
     }
+  }
+  .purchases-alert {
+    color: red;
   }
 }

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -2,7 +2,7 @@ class PurchasesController < ApplicationController
   before_action :secret_key, only: [:index, :pay]
   before_action :set_card, only: [:index, :pay]
   before_action :set_item, only: [:index, :pay]
-  before_action :done, only: [:pay]
+  # before_action :done, only: [:pay]
   
   require 'payjp'
 
@@ -20,14 +20,16 @@ class PurchasesController < ApplicationController
 
     if @card.blank?
       #登録された情報がない場合にカード登録画面に移動
-      flash[:alert] = 'カードを登録してください'
-      render 'index'
+      flash[:card_touroku] = 'カードを登録してください'
+      # render 'index'
+      redirect_to purchases_path
     else
       Payjp::Charge.create(
       :amount => @item.price, #支払金額を入力（itemテーブル等に紐づけても良い）
       :customer => @card.customer_id, #顧客ID
       :currency => 'jpy', #日本円
     )
+    @item.update( purchaser_id: current_user.id, trading: 'SOLDOUT')
     redirect_to action: 'done' #完了画面に移動
     end
   end
@@ -46,8 +48,8 @@ class PurchasesController < ApplicationController
     @item = Item.find(params[:id])
   end
 
-  def  done
-    @item.update( purchaser_id: current_user.id, trading: 'SOLDOUT')
-  end
+  # def  done
+  #   @item.update( purchaser_id: current_user.id, trading: 'SOLDOUT')
+  # end
 
 end

--- a/app/views/cards/new.html.haml
+++ b/app/views/cards/new.html.haml
@@ -3,7 +3,8 @@
     .mypage-content.signup-main
       %section.mypage-content__chapter-container
         %h2.signup-main__chapter-head
-          クレジットカード情報入力
+          = link_to root_path do
+            クレジットカード情報入力
         = form_with model: @card, id: 'charge-form', class: 'signup-main__inner signup-main__inner--registration-form', novalidate: 'novalidate', html: { name: 'inputForm' } do |f|
           .signup-main__content
             .signup-main__form-group

--- a/app/views/cards/show.html.haml
+++ b/app/views/cards/show.html.haml
@@ -9,7 +9,8 @@
           %section
             .signup-main__content
               %h3.signup-main__chapter-sub-head
-                クレジットカード一覧
+                = link_to root_path do
+                  クレジットカード一覧
             %ul.mypage-content__payment-list
               %li
                 .signup-main__content.signup-main__content--form{ action: '#', method: 'GET' }

--- a/app/views/purchases/index.html.haml
+++ b/app/views/purchases/index.html.haml
@@ -58,8 +58,8 @@
                 = link_to new_address_path do
                   登録してください
               .purchases-buy-item
-                - flash.each do |key, value|
-                  = content_tag(:div, value, class: key)
+                .purchases-alert
+                  = flash[:card_touroku]
                 = form_tag(action: :pay, method: :post) do
                   %button.purchases-buy-item__btn 購入する
     .purchases-footer


### PR DESCRIPTION
# what
・エラーメッセージの修正。
・間違って購入ボタンを押してからカード登録をすると、購入した扱いになってしまうのを防いだ。
・cards/new、cards/showからすぐにトップページに行けるように設定した。

# why
より使いやすくするため。
勝手に購入させていたらサービスとしてひどいため。
